### PR TITLE
Ajuste rotina responsável por marcar uma tarefa como concluída

### DIFF
--- a/__tests__/integration/tasks.spec.js
+++ b/__tests__/integration/tasks.spec.js
@@ -65,6 +65,23 @@ describe('test suite for /tasks endpoint', () => {
     expect(response.body).toHaveProperty('id')
     expect(response.body).toHaveProperty('description')
     expect(response.body).toHaveProperty('estimate_date')
+    expect(response.body.estimate_date).not.toBeNull()
+    expect(response.body).toHaveProperty('done_date')
+    expect(response.body).toHaveProperty('notify')
+    expect(response.body).toHaveProperty('created_at')
+  })
+
+  it('should mark a task as done and responds with a object', async () => {
+    const taskId = (await request(app).get('/tasks').set('Authorization', accessToken)).body[0].id
+    const response = await request(app).put(`/tasks/${taskId}/done`).set('Authorization', accessToken)
+
+    expect(response.status).toBe(200)
+
+    // expects object
+    expect(response.body).toBeInstanceOf(Object)
+    expect(response.body).toHaveProperty('id')
+    expect(response.body).toHaveProperty('description')
+    expect(response.body).toHaveProperty('estimate_date')
     expect(response.body).toHaveProperty('done_date')
     expect(response.body).toHaveProperty('notify')
     expect(response.body).toHaveProperty('created_at')

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -70,7 +70,7 @@ const remove = async (id, userId) => {
 }
 
 const markAsDone = async (taskId, userId) => {
-  const task = await this.getById(taskId, userId)
+  const task = await getById(taskId, userId)
   const doneDate = task.done_date ? null : new Date()
 
   return (await knex('tasks').where({ id: taskId, user_id: userId }).update({ done_date: doneDate }, '*'))[0]


### PR DESCRIPTION
- Ajuste rotina responsável por marcar uma tarefa como concluída
- Criado teste de integração p/ endpoint /tasks/{id}/done